### PR TITLE
Could not use Toolbar commands from none-file-windows like the project properties window

### DIFF
--- a/TortoiseGitToolbar/Config/Constants/PathConfiguration.cs
+++ b/TortoiseGitToolbar/Config/Constants/PathConfiguration.cs
@@ -74,11 +74,25 @@ namespace MattDavies.TortoiseGitToolbar.Config.Constants
 
         public static string GetOpenedFilePath(Solution2 solution)
         {
-            return solution != null && solution.DTE != null && solution.DTE.ActiveDocument != null
+            if (solution != null && solution.DTE != null)
+            {
+                try
+                {
+                    if (solution.DTE.ActiveDocument == null) // no active window
+                        return null;
+                }
+                catch (ArgumentException)
+                {
+                    // active window is no file (e.g. the project properties)
+                    return null;
+                }
+
                 // GetExactPathName is needed because visual studio can provide lowercase path,
                 // but git is case sensitive to file names
-                ? GetExactPathName(solution.DTE.ActiveDocument.FullName)
-                : null;
+                return GetExactPathName(solution.DTE.ActiveDocument.FullName);
+            }
+
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
As the title says there was an error when triggering any command when the project properties window was active. This is beacuse solution.DTE.ActiveDocument throws an exception in this case rather than returning null.

I could not really test this because I can no longer open the solution with VS 2015. Setting the MinimumVisualStudioVersion to 14.0 lets me open the solution but I get build errors of which I read that I need to install VS 2017 to resolve them which I do not have.