### PR TITLE
Improved git repository directory detection

### DIFF
--- a/TortoiseGitToolbar.Shared/Config/Constants/PathConfiguration.cs
+++ b/TortoiseGitToolbar.Shared/Config/Constants/PathConfiguration.cs
@@ -45,7 +45,7 @@ namespace MattDavies.TortoiseGitToolbar.Config.Constants
 
         public static string GetSolutionPath(Solution2 solution)
         {
-            if (solution != null && solution.IsOpen)
+            if (solution != null && !String.IsNullOrEmpty(solution.FullName))
             {
                 var solutionPathFromSln = Path.GetDirectoryName(solution.FullName);
 

--- a/TortoiseGitToolbar.Shared/Resources/Resources.Designer.cs
+++ b/TortoiseGitToolbar.Shared/Resources/Resources.Designer.cs
@@ -8,10 +8,11 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace MattDavies.TortoiseGitToolbar.Resources {
+namespace MattDavies.TortoiseGitToolbar.Resources
+{
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,97 +23,117 @@ namespace MattDavies.TortoiseGitToolbar.Resources {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
-        
+    internal class Resources
+    {
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources() {
+        internal Resources()
+        {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MattDavies.TortoiseGitToolbar.Resources.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not find Git Bash in the registry or the standard install path..
         /// </summary>
-        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_Git_Bash_in_the_standard_install_path_ {
-            get {
+        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_Git_Bash_in_the_standard_install_path_
+        {
+            get
+            {
                 return ResourceManager.GetString("TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_Git_Bash_in_the_sta" +
                         "ndard_install_path_", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not find TortoiseGit in the registry or the standard install path..
         /// </summary>
-        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_TortoiseGit_in_the_standard_install_path_ {
-            get {
+        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_TortoiseGit_in_the_standard_install_path_
+        {
+            get
+            {
                 return ResourceManager.GetString("TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_TortoiseGit_in_the_" +
                         "standard_install_path_", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Git Bash not found.
         /// </summary>
-        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Git_Bash_not_found {
-            get {
+        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Git_Bash_not_found
+        {
+            get
+            {
                 return ResourceManager.GetString("TortoiseGitLauncherService_ExecuteTortoiseProc_Git_Bash_not_found", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to TortoiseGit not found.
         /// </summary>
-        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_TortoiseGit_not_found {
-            get {
+        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_TortoiseGit_not_found
+        {
+            get
+            {
                 return ResourceManager.GetString("TortoiseGitLauncherService_ExecuteTortoiseProc_TortoiseGit_not_found", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No solution found..
         /// </summary>
-        internal static string TortoiseGitLauncherService_SolutionPath_No_solution_found {
-            get {
-                return ResourceManager.GetString("TortoiseGitLauncherService_SolutionPath_No_solution_found", resourceCulture);
+        internal static string TortoiseGitLauncherService_GitRepositoryNotFoundCaption
+        {
+            get
+            {
+                return ResourceManager.GetString("TortoiseGitLauncherService_GitRepositoryNotFoundCaption", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to You need to open a solution first!.
         /// </summary>
-        internal static string TortoiseGitLauncherService_SolutionPath_You_need_to_open_a_solution_first {
-            get {
-                return ResourceManager.GetString("TortoiseGitLauncherService_SolutionPath_You_need_to_open_a_solution_first", resourceCulture);
+        internal static string TortoiseGitLauncherService_GitRepositoryNotFound
+        {
+            get
+            {
+                return ResourceManager.GetString("TortoiseGitLauncherService_GitRepositoryNotFound", resourceCulture);
             }
         }
     }

--- a/TortoiseGitToolbar.Shared/Resources/Resources.resx
+++ b/TortoiseGitToolbar.Shared/Resources/Resources.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+	<!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,80 +59,80 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
-  <resheader name="resmimetype">
-    <value>text/microsoft-resx</value>
-  </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
-  <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <data name="TortoiseGitLauncherService_SolutionPath_You_need_to_open_a_solution_first" xml:space="preserve">
-    <value>You need to open a solution first!</value>
+	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+		<xsd:element name="root" msdata:IsDataSet="true">
+			<xsd:complexType>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="metadata">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" />
+							</xsd:sequence>
+							<xsd:attribute name="name" use="required" type="xsd:string" />
+							<xsd:attribute name="type" type="xsd:string" />
+							<xsd:attribute name="mimetype" type="xsd:string" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="assembly">
+						<xsd:complexType>
+							<xsd:attribute name="alias" type="xsd:string" />
+							<xsd:attribute name="name" type="xsd:string" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="data">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="resheader">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:complexType>
+		</xsd:element>
+	</xsd:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="TortoiseGitLauncherService_GitRepositoryNotFound" xml:space="preserve">
+    <value>You need to open a file or solution that resides inside a git repository!</value>
   </data>
-  <data name="TortoiseGitLauncherService_SolutionPath_No_solution_found" xml:space="preserve">
-    <value>No solution found.</value>
+	<data name="TortoiseGitLauncherService_GitRepositoryNotFoundCaption" xml:space="preserve">
+    <value>Git repository not found.</value>
   </data>
-  <data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_Git_Bash_in_the_standard_install_path_" xml:space="preserve">
+	<data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_Git_Bash_in_the_standard_install_path_" xml:space="preserve">
     <value>Could not find Git Bash in the registry or the standard install path.</value>
   </data>
-  <data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Git_Bash_not_found" xml:space="preserve">
+	<data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Git_Bash_not_found" xml:space="preserve">
     <value>Git Bash not found</value>
   </data>
-  <data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_TortoiseGit_in_the_standard_install_path_" xml:space="preserve">
+	<data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_TortoiseGit_in_the_standard_install_path_" xml:space="preserve">
     <value>Could not find TortoiseGit in the registry or the standard install path.</value>
   </data>
-  <data name="TortoiseGitLauncherService_ExecuteTortoiseProc_TortoiseGit_not_found" xml:space="preserve">
+	<data name="TortoiseGitLauncherService_ExecuteTortoiseProc_TortoiseGit_not_found" xml:space="preserve">
     <value>TortoiseGit not found</value>
   </data>
 </root>

--- a/TortoiseGitToolbar.Shared/Services/TortoiseGitLauncherService.cs
+++ b/TortoiseGitToolbar.Shared/Services/TortoiseGitLauncherService.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
+using System.IO;
 using System.Windows.Forms;
 using EnvDTE80;
 using MattDavies.TortoiseGitToolbar.Config.Constants;
@@ -22,12 +24,56 @@ namespace MattDavies.TortoiseGitToolbar.Services
             _solution = solution;
         }
 
+        private string FindGitRepositoryRootPath(DirectoryInfo dirInfo)
+        {
+            while (dirInfo != null && dirInfo.Exists)
+            {
+                string gitPath = dirInfo.FullName + "/.git";
+                // Check for a .git directory
+                if (Directory.Exists(gitPath))
+                {
+                    return dirInfo.FullName;
+                }
+                // Check for a .git file (submodule)
+                if (File.Exists(gitPath))
+                {
+                    return dirInfo.FullName;
+                }
+                // git repo not found, look at the parent level.
+                dirInfo = dirInfo.Parent;
+            }
+
+            return null;
+        }
+
+        private string GitRepositoryRootPath(string selectedFile, string solutionPath)
+        {
+            if (!String.IsNullOrEmpty(selectedFile))
+            {
+                var selectedInfo = new FileInfo(selectedFile);
+                string gitPath = FindGitRepositoryRootPath(selectedInfo.Directory);
+                if (!String.IsNullOrEmpty(gitPath))
+                {
+                    return gitPath;
+                }
+            }
+
+            if (!String.IsNullOrEmpty(solutionPath))
+            {
+                DirectoryInfo solutionDir = new DirectoryInfo(solutionPath);
+                return FindGitRepositoryRootPath(solutionDir);
+            }
+
+            return null;
+        }
+
         public void ExecuteTortoiseProc(ToolbarCommand command)
         {
             var solutionPath = PathConfiguration.GetSolutionPath(_solution);
             var openedFilePath = PathConfiguration.GetOpenedFilePath(_solution);
             // todo: make the bash/tortoise paths configurable
             // todo: detect if the solution is a git solution first
+            var gitRepoPath = GitRepositoryRootPath(openedFilePath, solutionPath);
             if (command == ToolbarCommand.Bash && PathConfiguration.GetGitBashPath() == null)
             {
                 MessageBox.Show(
@@ -38,11 +84,11 @@ namespace MattDavies.TortoiseGitToolbar.Services
                 );
                 return;
             }
-            if (command != ToolbarCommand.Bash && solutionPath == null)
+            if (command != ToolbarCommand.Bash && gitRepoPath == null)
             {
                 MessageBox.Show(
-                    Resources.Resources.TortoiseGitLauncherService_SolutionPath_You_need_to_open_a_solution_first,
-                    Resources.Resources.TortoiseGitLauncherService_SolutionPath_No_solution_found,
+                    Resources.Resources.TortoiseGitLauncherService_GitRepositoryNotFound,
+                    Resources.Resources.TortoiseGitLauncherService_GitRepositoryNotFoundCaption,
                     MessageBoxButtons.OK,
                     MessageBoxIcon.Exclamation
                 );
@@ -66,14 +112,14 @@ namespace MattDavies.TortoiseGitToolbar.Services
                     process = _processManagerService.GetProcess(
                         PathConfiguration.GetGitBashPath(),
                         "--login -i",
-                        solutionPath
+                        gitRepoPath
                     );
                     break;
                 case ToolbarCommand.RebaseContinue:
                     process = _processManagerService.GetProcess(
                         PathConfiguration.GetGitBashPath(),
                         @"--login -i -c 'echo; echo ""Running git rebase --continue""; echo; git rebase --continue; echo; echo ""Please review the output above and press enter to continue.""; read'",
-                        solutionPath
+                        gitRepoPath
                     );
                     break;
                 case ToolbarCommand.FileLog:
@@ -94,13 +140,13 @@ namespace MattDavies.TortoiseGitToolbar.Services
                 case ToolbarCommand.StashList:
                     process = _processManagerService.GetProcess(
                         PathConfiguration.GetTortoiseGitPath(),
-                        string.Format(@"/command:reflog /path:""{0}"" /ref:""refs/stash""", solutionPath)
+                        string.Format(@"/command:reflog /path:""{0}"" /ref:""refs/stash""", gitRepoPath)
                     );
                     break;
                 default:
                     process = _processManagerService.GetProcess(
                         PathConfiguration.GetTortoiseGitPath(),
-                        string.Format(@"/command:{0} /path:""{1}""", command.ToString().ToLower(), solutionPath)
+                        string.Format(@"/command:{0} /path:""{1}""", command.ToString().ToLower(), gitRepoPath)
                     );
                     break;
             }

--- a/TortoiseGitToolbar/source.extension.vsixmanifest
+++ b/TortoiseGitToolbar/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="f388ee16-eef2-4ae1-85bd-4cb19151beb0" Version="1.0.6" Language="en-US" Publisher="mdaviesnet" />
+        <Identity Id="f388ee16-eef2-4ae1-85bd-4cb19151beb0" Version="1.0.8" Language="en-US" Publisher="mdaviesnet" />
         <DisplayName>TortoiseGit Toolbar</DisplayName>
         <Description xml:space="preserve">Lightweight toolbar for launching commonly used TortoiseGit functionality from within Visual Studio.</Description>
         <MoreInfo>https://github.com/MattDavies/TortoiseGitToolbar</MoreInfo>


### PR DESCRIPTION
Added support for out of source builds where the solution file is not in the repository (CMAKE, etc).
Added support for large projects using multiple git repositories.
Added support for submodules.

The git repository directory is now determined from the current file first, then the solution if there is no current file. When determining the git repository, if the file/solution is in a submodule, that will be used rather than the super project.

The plugin has two types of commands "file" (File Log, File Blame, and File Diff) and "repo" (the rest). The "repo" commands now work whether the solution is in a repository or not as long as there is a currently open file that is in a git repository.

If you happen to be working on a project with a checked in solution file, this plugin will work exactly as before with one improvement. If the solution file is not at the root of the repository, the repository root will now be use instead of assuming the solution file is at the repository root which produced very odd behavior (your changes might not show up in the commit dialog).

Updated the version number.