### PR TITLE
Improved locating the git repository root

### DIFF
--- a/TortoiseGitToolbar.Shared/Resources/Resources.Designer.cs
+++ b/TortoiseGitToolbar.Shared/Resources/Resources.Designer.cs
@@ -8,10 +8,11 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace MattDavies.TortoiseGitToolbar.Resources {
+namespace MattDavies.TortoiseGitToolbar.Resources
+{
     using System;
-    
-    
+
+
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,97 +23,117 @@ namespace MattDavies.TortoiseGitToolbar.Resources {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
-        
+    internal class Resources
+    {
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources() {
+        internal Resources()
+        {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("MattDavies.TortoiseGitToolbar.Resources.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not find Git Bash in the registry or the standard install path..
         /// </summary>
-        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_Git_Bash_in_the_standard_install_path_ {
-            get {
+        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_Git_Bash_in_the_standard_install_path_
+        {
+            get
+            {
                 return ResourceManager.GetString("TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_Git_Bash_in_the_sta" +
                         "ndard_install_path_", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Could not find TortoiseGit in the registry or the standard install path..
         /// </summary>
-        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_TortoiseGit_in_the_standard_install_path_ {
-            get {
+        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_TortoiseGit_in_the_standard_install_path_
+        {
+            get
+            {
                 return ResourceManager.GetString("TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_TortoiseGit_in_the_" +
                         "standard_install_path_", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Git Bash not found.
         /// </summary>
-        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Git_Bash_not_found {
-            get {
+        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_Git_Bash_not_found
+        {
+            get
+            {
                 return ResourceManager.GetString("TortoiseGitLauncherService_ExecuteTortoiseProc_Git_Bash_not_found", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to TortoiseGit not found.
         /// </summary>
-        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_TortoiseGit_not_found {
-            get {
+        internal static string TortoiseGitLauncherService_ExecuteTortoiseProc_TortoiseGit_not_found
+        {
+            get
+            {
                 return ResourceManager.GetString("TortoiseGitLauncherService_ExecuteTortoiseProc_TortoiseGit_not_found", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to No solution found..
         /// </summary>
-        internal static string TortoiseGitLauncherService_SolutionPath_No_solution_found {
-            get {
-                return ResourceManager.GetString("TortoiseGitLauncherService_SolutionPath_No_solution_found", resourceCulture);
+        internal static string TortoiseGitLauncherService_GitRepositoryNotFoundCaption
+        {
+            get
+            {
+                return ResourceManager.GetString("TortoiseGitLauncherService_GitRepositoryNotFoundCaption", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to You need to open a solution first!.
         /// </summary>
-        internal static string TortoiseGitLauncherService_SolutionPath_You_need_to_open_a_solution_first {
-            get {
-                return ResourceManager.GetString("TortoiseGitLauncherService_SolutionPath_You_need_to_open_a_solution_first", resourceCulture);
+        internal static string TortoiseGitLauncherService_GitRepositoryNotFound
+        {
+            get
+            {
+                return ResourceManager.GetString("TortoiseGitLauncherService_GitRepositoryNotFound", resourceCulture);
             }
         }
     }

--- a/TortoiseGitToolbar.Shared/Resources/Resources.resx
+++ b/TortoiseGitToolbar.Shared/Resources/Resources.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+	<!-- 
     Microsoft ResX Schema 
     
     Version 2.0
@@ -59,80 +59,80 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
-  <resheader name="resmimetype">
-    <value>text/microsoft-resx</value>
-  </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
-  <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </resheader>
-  <data name="TortoiseGitLauncherService_SolutionPath_You_need_to_open_a_solution_first" xml:space="preserve">
-    <value>You need to open a solution first!</value>
+	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+		<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+		<xsd:element name="root" msdata:IsDataSet="true">
+			<xsd:complexType>
+				<xsd:choice maxOccurs="unbounded">
+					<xsd:element name="metadata">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" />
+							</xsd:sequence>
+							<xsd:attribute name="name" use="required" type="xsd:string" />
+							<xsd:attribute name="type" type="xsd:string" />
+							<xsd:attribute name="mimetype" type="xsd:string" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="assembly">
+						<xsd:complexType>
+							<xsd:attribute name="alias" type="xsd:string" />
+							<xsd:attribute name="name" type="xsd:string" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="data">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+							<xsd:attribute ref="xml:space" />
+						</xsd:complexType>
+					</xsd:element>
+					<xsd:element name="resheader">
+						<xsd:complexType>
+							<xsd:sequence>
+								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+							</xsd:sequence>
+							<xsd:attribute name="name" type="xsd:string" use="required" />
+						</xsd:complexType>
+					</xsd:element>
+				</xsd:choice>
+			</xsd:complexType>
+		</xsd:element>
+	</xsd:schema>
+	<resheader name="resmimetype">
+		<value>text/microsoft-resx</value>
+	</resheader>
+	<resheader name="version">
+		<value>2.0</value>
+	</resheader>
+	<resheader name="reader">
+		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<resheader name="writer">
+		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+	</resheader>
+	<data name="TortoiseGitLauncherService_GitRepositoryNotFound" xml:space="preserve">
+    <value>You need to open a file or solution that resides inside a git repository!</value>
   </data>
-  <data name="TortoiseGitLauncherService_SolutionPath_No_solution_found" xml:space="preserve">
-    <value>No solution found.</value>
+	<data name="TortoiseGitLauncherService_GitRepositoryNotFoundCaption" xml:space="preserve">
+    <value>Git repository not found.</value>
   </data>
-  <data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_Git_Bash_in_the_standard_install_path_" xml:space="preserve">
+	<data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_Git_Bash_in_the_standard_install_path_" xml:space="preserve">
     <value>Could not find Git Bash in the registry or the standard install path.</value>
   </data>
-  <data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Git_Bash_not_found" xml:space="preserve">
+	<data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Git_Bash_not_found" xml:space="preserve">
     <value>Git Bash not found</value>
   </data>
-  <data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_TortoiseGit_in_the_standard_install_path_" xml:space="preserve">
+	<data name="TortoiseGitLauncherService_ExecuteTortoiseProc_Could_not_find_TortoiseGit_in_the_standard_install_path_" xml:space="preserve">
     <value>Could not find TortoiseGit in the registry or the standard install path.</value>
   </data>
-  <data name="TortoiseGitLauncherService_ExecuteTortoiseProc_TortoiseGit_not_found" xml:space="preserve">
+	<data name="TortoiseGitLauncherService_ExecuteTortoiseProc_TortoiseGit_not_found" xml:space="preserve">
     <value>TortoiseGit not found</value>
   </data>
 </root>

--- a/TortoiseGitToolbar.Shared/TortoiseGitToolbar.Shared.projitems
+++ b/TortoiseGitToolbar.Shared/TortoiseGitToolbar.Shared.projitems
@@ -11,7 +11,6 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Config\Constants\PathConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Config\Constants\ToolbarCommand.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Config\SettingsDialog.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Resources\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/TortoiseGitToolbar.Shared/TortoiseGitToolbarPackage.cs
+++ b/TortoiseGitToolbar.Shared/TortoiseGitToolbarPackage.cs
@@ -14,7 +14,6 @@ namespace MattDavies.TortoiseGitToolbar
     [ProvideMenuResource("Menus.ctmenu", 1)]
     [Guid(PackageConstants.GuidTortoiseGitToolbarPkgString)]
     [ProvideKeyBindingTable(PackageConstants.GuidTortoiseGitToolbarPkgString, 110)]
-    [ProvideOptionPage(typeof(Config.SettingsDialog), Config.GlobalConfig.ExtensionName, "General", 0, 0, true)]
     public sealed class TortoiseGitToolbarPackage : Package
     {
         private OleMenuCommandService _commandService;

--- a/TortoiseGitToolbar.UnitTests/Services/TortoiseGitLauncherServiceTests.cs
+++ b/TortoiseGitToolbar.UnitTests/Services/TortoiseGitLauncherServiceTests.cs
@@ -15,7 +15,7 @@ namespace TortoiseGitToolbar.UnitTests.Services
     [Collection(MockedVS.Collection)]
     public class TortoiseGitLauncherServiceShould
     {
-        public static IEnumerable<object[]> TortoiseCommands = Enum.GetValues(typeof(ToolbarCommand)).Cast<ToolbarCommand>().Where(t => t != ToolbarCommand.Bash && t != ToolbarCommand.RebaseContinue).Select(t => new object[]{t});
+        public static IEnumerable<object[]> TortoiseCommands = Enum.GetValues(typeof(ToolbarCommand)).Cast<ToolbarCommand>().Where(t => t != ToolbarCommand.Bash && t != ToolbarCommand.RebaseContinue).Select(t => new object[] { t });
         private readonly IProcessManagerService _processManagerService;
         private static readonly string TestFilePath = Path.Combine(Environment.CurrentDirectory, "test.txt");
         private const int CurrentLine = 42;
@@ -54,7 +54,7 @@ namespace TortoiseGitToolbar.UnitTests.Services
             _processManagerService.Received().GetProcess(
                 GetExpectedCommand(command),
                 GetExpectedParameters(command),
-                PathConfiguration.GetSolutionPath(solution)
+                PathConfiguration.GetRepositoryRootPath(solution)
             );
         }
 
@@ -70,7 +70,7 @@ namespace TortoiseGitToolbar.UnitTests.Services
             _processManagerService.Received().GetProcess(
                 GetExpectedCommand(command),
                 GetExpectedParameters(command),
-                PathConfiguration.GetSolutionPath(solution)
+                PathConfiguration.GetRepositoryRootPath(solution)
             );
         }
 
@@ -78,8 +78,9 @@ namespace TortoiseGitToolbar.UnitTests.Services
         public void Get_solution_folder_traverses_parents_till_git_folder_found()
         {
             var solution = GetOpenSolution();
-            var solutionPath = PathConfiguration.GetSolutionPath(solution);
-            Assert.True(Directory.Exists(Path.Combine(solutionPath, ".git")), "Returned solution path is not the repository root.");
+            var gitRepoRoot = PathConfiguration.GetRepositoryRootPath(solution);
+            var dotGitPath = Path.Combine(gitRepoRoot, ".git");
+            Assert.True(Directory.Exists(dotGitPath) || File.Exists(dotGitPath), "Returned path is not the repository root.");
         }
 
         private static Solution2 GetOpenSolution()
@@ -132,7 +133,7 @@ namespace TortoiseGitToolbar.UnitTests.Services
 
         private static string GetExpectedParameters(ToolbarCommand toolbarCommand)
         {
-            var solutionPath = PathConfiguration.GetSolutionPath(GetOpenSolution());
+            var gitRepoRoot = PathConfiguration.GetRepositoryRootPath(GetOpenSolution());
             switch (toolbarCommand)
             {
                 case ToolbarCommand.Bash:
@@ -140,35 +141,35 @@ namespace TortoiseGitToolbar.UnitTests.Services
                 case ToolbarCommand.RebaseContinue:
                     return @"--login -i -c 'echo; echo ""Running git rebase --continue""; echo; git rebase --continue; echo; echo ""Please review the output above and press enter to continue.""; read'";
                 case ToolbarCommand.Commit:
-                    return $@"/command:commit /path:""{solutionPath}""";
+                    return $@"/command:commit /path:""{gitRepoRoot}""";
                 case ToolbarCommand.Log:
-                    return $@"/command:log /path:""{solutionPath}""";
+                    return $@"/command:log /path:""{gitRepoRoot}""";
                 case ToolbarCommand.Pull:
-                    return $@"/command:pull /path:""{solutionPath}""";
+                    return $@"/command:pull /path:""{gitRepoRoot}""";
                 case ToolbarCommand.Push:
-                    return $@"/command:push /path:""{solutionPath}""";
+                    return $@"/command:push /path:""{gitRepoRoot}""";
                 case ToolbarCommand.Switch:
-                    return $@"/command:switch /path:""{solutionPath}""";
+                    return $@"/command:switch /path:""{gitRepoRoot}""";
                 case ToolbarCommand.Cleanup:
-                    return $@"/command:cleanup /path:""{solutionPath}""";
+                    return $@"/command:cleanup /path:""{gitRepoRoot}""";
                 case ToolbarCommand.Fetch:
-                    return $@"/command:fetch /path:""{solutionPath}""";
+                    return $@"/command:fetch /path:""{gitRepoRoot}""";
                 case ToolbarCommand.Revert:
-                    return $@"/command:revert /path:""{solutionPath}""";
+                    return $@"/command:revert /path:""{gitRepoRoot}""";
                 case ToolbarCommand.Sync:
-                    return $@"/command:sync /path:""{solutionPath}""";
+                    return $@"/command:sync /path:""{gitRepoRoot}""";
                 case ToolbarCommand.Merge:
-                    return $@"/command:merge /path:""{solutionPath}""";
+                    return $@"/command:merge /path:""{gitRepoRoot}""";
                 case ToolbarCommand.Resolve:
-                    return $@"/command:resolve /path:""{solutionPath}""";
+                    return $@"/command:resolve /path:""{gitRepoRoot}""";
                 case ToolbarCommand.StashSave:
-                    return $@"/command:stashsave /path:""{solutionPath}""";
+                    return $@"/command:stashsave /path:""{gitRepoRoot}""";
                 case ToolbarCommand.StashPop:
-                    return $@"/command:stashpop /path:""{solutionPath}""";
+                    return $@"/command:stashpop /path:""{gitRepoRoot}""";
                 case ToolbarCommand.StashList:
-                    return $@"/command:reflog /path:""{solutionPath}"" /ref:""refs/stash""";
+                    return $@"/command:reflog /path:""{gitRepoRoot}"" /ref:""refs/stash""";
                 case ToolbarCommand.Rebase:
-                    return $@"/command:rebase /path:""{solutionPath}""";
+                    return $@"/command:rebase /path:""{gitRepoRoot}""";
                 case ToolbarCommand.FileBlame:
                     return $@"/command:blame /path:""{TestFilePath}"" /line:{CurrentLine}";
                 case ToolbarCommand.FileDiff:

--- a/TortoiseGitToolbar/source.extension.vsixmanifest
+++ b/TortoiseGitToolbar/source.extension.vsixmanifest
@@ -11,9 +11,6 @@
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
-        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
-            <ProductArchitecture>arm64</ProductArchitecture>
-        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
Added support native for projects where the solution file is not in the git repository.
Added support for working on files without a solution loaded.
Added support for worktrees and submodules (".git" is a file rather than directory)

Commit 5ef6f85365d31fe1ed3eb29b6d72a5d9c8e8cefa
Changed GetSolutionPath to return the repository root.
This was done by looking for ".git", however; it only checked for a directory by that name.
When using submodules and worktrees, ".git" is a file not a directory.
This also changed the behavior of the function without changing its name which is confusing.
Both of these issues were resolved.

PR #21 - Git worktree support
The above fix works for submodules and worktrees and thus these changes were no longer needed.
This removes a ton of code and unnecessary complexity.

PR #29 - Support for VS2022 on ARM
The code does not build with this change.
In order to get the code to build, NuGet packages would need to be updated.
I am not sure if that would break the VS2019 version, but that seems likely.
This change was removed in order to build the code.

PR #30 - Fix for auto-generated solutions such as CMake
Added an unnecessary preference setting.
Used the current file for "repository" commands, and thus did not work correctly.
PR #30 has been superseded by this commit.

Added GetRepositoryRootPath() to retrieve the git repository root path.
This searches using the current file, if there is one, then using the solution file, if one is open.

Updated the code to call GetRepositoryRootPath() in all locations that need the repository root.
Updated variables for correctness and clarity (i.e. gitRepoPath instead of solutionPath).
Updated error message when a git repository root cannot be found.
